### PR TITLE
feat: Add playwright chromium installation to postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "prepare": "pnpm run build",
+    "postinstall": "playwright install chromium",
     "watch": "tsc --watch",
     "dev": "tsx watch index.ts"
   },


### PR DESCRIPTION
- Ensure chromium browser is installed automatically after package install
- Simplify setup process for new development environments

Fixes #2