### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MCP Web Research Server
+[![smithery badge](https://smithery.ai/badge/@mzxrai/mcp-webresearch)](https://smithery.ai/server/@mzxrai/mcp-webresearch)
 
 A Model Context Protocol (MCP) server for web research. 
 
@@ -17,7 +18,15 @@ Bring real-time info into Claude and easily research any topic.
 - [Claude Desktop app](https://claude.ai/download)
 
 ## Installation
+### Installing via Smithery
 
+To install MCP Web Research Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@mzxrai/mcp-webresearch):
+
+```bash
+npx -y @smithery/cli install @mzxrai/mcp-webresearch --client claude
+```
+
+### Installing Manually
 First, ensure you've downloaded and installed the [Claude Desktop app](https://claude.ai/download) and you have npm installed.
 
 Next, add this entry to your `claude_desktop_config.json` (on Mac, found at `~/Library/Application\ Support/Claude/claude_desktop_config.json`):
@@ -128,4 +137,4 @@ MIT
 
 ## Author
 
-[mzxrai](https://github.com/mzxrai) 
+[mzxrai](https://github.com/mzxrai)


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Web Research Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@mzxrai/mcp-webresearch

Let me know if any tweaks have to be made!